### PR TITLE
Resolves #12 - Issue with comments when flattening SQL file

### DIFF
--- a/ethereum_bigquery_to_gcs.sh
+++ b/ethereum_bigquery_to_gcs.sh
@@ -24,8 +24,9 @@ export_temp_contracts_table="flattened_contracts"
 bq rm -r -f ${export_temp_dataset}
 bq mk ${export_temp_dataset}
 
-flatten_crypto_ethereum_logs_sql=$(cat ./flatten_crypto_ethereum_logs.sql | tr '\n' ' ')
-flatten_crypto_ethereum_contracts_sql=$(cat ./flatten_crypto_ethereum_contracts.sql | tr '\n' ' ')
+# Use awk to trim comments in sql files.
+flatten_crypto_ethereum_logs_sql=$(cat ./flatten_crypto_ethereum_logs.sql | awk -F '--' '{print $1}'| tr '\n' ' ')
+flatten_crypto_ethereum_contracts_sql=$(cat ./flatten_crypto_ethereum_contracts.sql | awk -F '--' '{print $1}' |  tr '\n' ' ')
 
 if [ "${filter_date}" = "true" ]; then
     flatten_crypto_ethereum_logs_sql="${flatten_crypto_ethereum_logs_sql} where date(block_timestamp) >= '${start_date}' and date(block_timestamp) <= '${end_date}'"

--- a/ethereumetl_postgres/gcs_compose.py
+++ b/ethereumetl_postgres/gcs_compose.py
@@ -17,7 +17,7 @@ args = parser.parse_args()
 
 
 def compose(bucket_name, source_prefix, destination_prefix, max_size_in_bytes):
-    print('Composing files in {} to {}'.format(f'gs://{bucket_name}{source_prefix}', f'gs://{bucket_name}{destination_prefix}'))
+    print('Composing files in {} to {}'.format(f'gs://{bucket_name}/{source_prefix}', f'gs://{bucket_name}/{destination_prefix}'))
     storage_client = storage.Client()
 
     blobs = storage_client.list_blobs(bucket_name, prefix=source_prefix)


### PR DESCRIPTION
Fixes error that blocked contracts export from BigQuery to GCS (#12 ). 

Could also be resolved by removing the comment in `flatten_crypto_ethereum_contracts.sql`.