### PR TITLE
Add function_sighashes to Tokens schema

### DIFF
--- a/schema/tokens.sql
+++ b/schema/tokens.sql
@@ -7,5 +7,6 @@ create table tokens
     total_supply numeric(78),
     block_number bigint,
     block_hash varchar(66),
-    block_timestamp timestamp
+    block_timestamp timestamp,
+    function_sighashes text[]
 );


### PR DESCRIPTION
In Streaming, the Schema of a Tokens contains the function_sighashes field.