### PR TITLE
Fix migrating block_hash for contract data

### DIFF
--- a/flatten_crypto_ethereum_contracts.sql
+++ b/flatten_crypto_ethereum_contracts.sql
@@ -8,5 +8,6 @@ select
     is_erc20,
     is_erc721,
     block_number,
-    block_timestamp
+    block_timestamp,
+    block_hash
 from `bigquery-public-data.crypto_ethereum.contracts`


### PR DESCRIPTION
# WHY
So we can also extract contract blockhash data from BigQuery Ethereum dataset

We have the PostgreSQL schema referencing it, but the current script doesn't actually migrate that data over it
https://github.com/blockchain-etl/ethereum-etl-postgres/blob/f3e806640f509bfd8e5fba0c7eaf2ed6b89b6fa0/schema/contracts.sql#L9