### PR TITLE
Resolved a syntax error in the schema: Removed arguments for an integer datatype

### DIFF
--- a/schema/tokens.sql
+++ b/schema/tokens.sql
@@ -3,7 +3,7 @@ create table tokens
     address varchar(42),
     name text,
     symbol text,
-    decimals int(11),
+    decimals int,
     total_supply numeric(78),
     block_number bigint,
     block_hash varchar(66),


### PR DESCRIPTION
When I ran `cat schema/*.sql | psql -U <my_db_username> -d <my_db_name> -h <my_host_address>  --port <my_port> -a` I got the following error for the `tokens` table:

```
(
    address varchar(42),
    name text,
    symbol text,
    decimals int(11),
    total_supply numeric(78),
    block_number bigint,
    block_hash varchar(66),
    block_timestamp timestamp
);
ERROR:  syntax error at or near "("
LINE 6:     decimals int(11),
```

Upon reviewing the code for the `schema/tokens.sql` file, I saw that it had a size specified for the integer datatype and the `int` datatype in PostgreSQL does not take any arguments.