### PR TITLE
🐞 fix: Insert field does not match

### DIFF
--- a/schema/transactions.sql
+++ b/schema/transactions.sql
@@ -21,9 +21,8 @@ create table transactions
     max_priority_fee_per_gas bigint,
     transaction_type bigint,
     receipt_effective_gas_price bigint,
-    effective_gas_price bigint,
-    l1_fee bigint,
-    l1_gas_used bigint,
-    l1_gas_price bigint,
-    l1_fee_scalar decimal
+    receipt_l1_fee bigint,
+    receipt_l1_gas_used bigint,
+    receipt_l1_gas_price bigint,
+    receipt_l1_fee_scalar decimal
 );


### PR DESCRIPTION
I found that the ETL loading fields did not match the fields in transactions.sql. After changing the field names in transactions.sql, it was able to be used normally.

Error:
```
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/blockchainetl/streaming/streamer.py", line 77, in _do_stream
    synced_blocks = self._sync_cycle()
  File "/usr/local/lib/python3.9/site-packages/blockchainetl/streaming/streamer.py", line 98, in _sync_cycle
    self.blockchain_streamer_adapter.export_all(self.last_synced_block + 1, target_block)
  File "/usr/local/lib/python3.9/site-packages/ethereumetl/streaming/eth_streamer_adapter.py", line 103, in export_all
    self.item_exporter.export_items(all_items)
  File "/usr/local/lib/python3.9/site-packages/blockchainetl/jobs/exporters/multi_item_exporter.py", line 34, in export_items
    exporter.export_items(items)
  File "/usr/local/lib/python3.9/site-packages/blockchainetl/jobs/exporters/postgres_item_exporter.py", line 51, in export_items
    connection.execute(insert_stmt, converted_items)
  File "/usr/local/lib64/python3.9/site-packages/sqlalchemy/engine/base.py", line 1200, in execute
    return meth(self, multiparams, params, _EMPTY_EXECUTION_OPTS)
  File "/usr/local/lib64/python3.9/site-packages/sqlalchemy/sql/elements.py", line 313, in _execute_on_connection
    return connection._execute_clauseelement(
  File "/usr/local/lib64/python3.9/site-packages/sqlalchemy/engine/base.py", line 1389, in _execute_clauseelement
    ret = self._execute_context(
  File "/usr/local/lib64/python3.9/site-packages/sqlalchemy/engine/base.py", line 1748, in _execute_context
    self._handle_dbapi_exception(
  File "/usr/local/lib64/python3.9/site-packages/sqlalchemy/engine/base.py", line 1929, in _handle_dbapi_exception
    util.raise_(
  File "/usr/local/lib64/python3.9/site-packages/sqlalchemy/util/compat.py", line 198, in raise_
    raise exception
  File "/usr/local/lib64/python3.9/site-packages/sqlalchemy/engine/base.py", line 1705, in _execute_context
    self.dialect.do_execute(
  File "/usr/local/lib64/python3.9/site-packages/sqlalchemy/engine/default.py", line 681, in do_execute
    cursor.execute(statement, parameters)
  File "/usr/local/lib/python3.9/site-packages/pg8000/core.py", line 341, in execute
    self._c.execute_unnamed(
  File "/usr/local/lib/python3.9/site-packages/pg8000/core.py", line 1225, in execute_unnamed
    self.handle_messages(cursor)
  File "/usr/local/lib/python3.9/site-packages/pg8000/core.py", line 1381, in handle_messages
    raise self.error
sqlalchemy.exc.ProgrammingError: (pg8000.exceptions.ProgrammingError) {'S': 'ERROR', 'V': 'ERROR', 'C': '42703', 'M': 'column "receipt_l1_fee" of relation "transactions" does not exist', 'P': '351', 'F': 'parse_target.c', 'L': '1052', 'R': 'checkInsertTargets'}

```